### PR TITLE
Update Guava and other dependencies versions

### DIFF
--- a/shared.gradle
+++ b/shared.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
 
     // Google common
-    implementation 'com.google.guava:guava:22.0'
+    implementation 'com.google.guava:guava:31.0.1-jre'
     implementation 'com.google.android.material:material:1.1.0'
 
     // Support library

--- a/shared.gradle
+++ b/shared.gradle
@@ -25,24 +25,24 @@ dependencies {
 
     // Google common
     implementation 'com.google.guava:guava:31.0.1-jre'
-    implementation 'com.google.android.material:material:1.1.0'
+    implementation 'com.google.android.material:material:1.4.0'
 
     // Support library
-    implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.annotation:annotation:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.4.0'
     implementation 'androidx.collection:collection:1.1.0'
-    implementation 'androidx.core:core:1.5.0-alpha01'
-    implementation 'androidx.fragment:fragment:1.2.0-rc03'
+    implementation 'androidx.core:core:1.7.0'
+    implementation 'androidx.fragment:fragment:1.4.0'
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
-    implementation 'androidx.preference:preference:1.1.0'
-    implementation 'androidx.recyclerview:recyclerview:1.1.0'
+    implementation 'androidx.preference:preference:1.1.1'
+    implementation 'androidx.recyclerview:recyclerview:1.2.0'
     implementation 'androidx.viewpager2:viewpager2:1.0.0'
 
     // Nullable
-    implementation 'org.checkerframework:checker-qual:2.5.8'
+    implementation 'org.checkerframework:checker-qual:3.19.0'
 
     // Auto-value
-    api 'com.google.auto.value:auto-value-annotations:1.7'
-    annotationProcessor 'com.google.auto.value:auto-value:1.7'
+    api 'com.google.auto.value:auto-value-annotations:1.8.2'
+    annotationProcessor 'com.google.auto.value:auto-value:1.8.2'
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
 }


### PR DESCRIPTION
* Guava update may fix [CVE-2018-10237](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-10237).
* Update of other dependencies also improves some functionality, e.g. follows interface size set in system preferences when dim screen message is displayed.