### PR TITLE
Bump dependency versions, fix upstream crash

### DIFF
--- a/shared.gradle
+++ b/shared.gradle
@@ -35,27 +35,27 @@ dependencies {
     // Google common
     implementation 'com.google.guava:guava:31.0.1-android'
     implementation 'com.google.android.gms:play-services-vision:20.1.3'
-    implementation 'com.google.android.material:material:1.1.0'
+    implementation 'com.google.android.material:material:1.5.0'
 
     // Support library
     implementation 'androidx.annotation:annotation:1.3.0'
-    implementation 'androidx.appcompat:appcompat:1.4.0'
+    implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'androidx.collection:collection:1.2.0'
     implementation 'androidx.core:core:1.7.0'
-    implementation 'androidx.fragment:fragment:1.4.0'
-    implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
-    implementation 'androidx.preference:preference:1.1.1'
+    implementation 'androidx.fragment:fragment:1.4.1'
+    implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.1.0'
+    implementation 'androidx.preference:preference:1.2.0'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'androidx.viewpager2:viewpager2:1.0.0'
 
     // Nullable
-    implementation 'org.checkerframework:checker-qual:2.5.8'
+    implementation 'org.checkerframework:checker-qual:3.21.3'
 
     // Auto-value
-    api 'com.google.auto.value:auto-value-annotations:1.7'
-    annotationProcessor 'com.google.auto.value:auto-value:1.7'
+    api 'com.google.auto.value:auto-value-annotations:1.9'
+    annotationProcessor 'com.google.auto.value:auto-value:1.9'
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
 
-    wearCompileOnly 'com.google.android.support:wearable:2.7.0'
-    //wearCompileOnly 'com.google.android.wearable:wearable:2.7.0'
+    wearCompileOnly 'com.google.android.support:wearable:2.9.0'
+    //wearCompileOnly 'com.google.android.wearable:wearable:2.9.0'
 }

--- a/talkback/src/main/res/layout/label_manager_packages.xml
+++ b/talkback/src/main/res/layout/label_manager_packages.xml
@@ -15,7 +15,7 @@
      limitations under the License.
 -->
 
-<android.support.v4.widget.NestedScrollView
+<androidx.core.widget.NestedScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
@@ -72,4 +72,4 @@
             android:visibility="gone" />
     </LinearLayout>
 
-</android.support.v4.widget.NestedScrollView>
+</androidx.core.widget.NestedScrollView>

--- a/talkback/src/main/res/values/strings.xml
+++ b/talkback/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!-- To aid tooling, any string-containing xml file in this project should have a filename beginning with "strings" -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">TalkBack</string>
+    <string name="app_name" translatable="false">TalkBack</string>
 
     <!--The human-readable name of this service. Do not translate. -->
     <string name="talkback_title" translatable="false">TalkBack</string>


### PR DESCRIPTION
* Bump dependency versions.
* Fix upstream crash - steps to reproduce: TalkBack settings -> Advanced settings -> Custom labels.