### PR TITLE
Update NDK in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: nttld/setup-ndk@v1
         id: setup-ndk
         with:
-          ndk-version: r25b
+          ndk-version: r26c
           link-to-sdk: true
       - name: Set up JDK 17
         uses: actions/setup-java@v4


### PR DESCRIPTION
App used NDK 26.2.11394342
[1](https://github.com/grapheneos/talkback/blob/main/braille/brltty/build.gradle#L6)
[2](https://github.com/grapheneos/talkback/blob/main/braille/translate/build.gradle#L6)

[Android NDK](https://github.com/android/ndk/releases/tag/r26c)